### PR TITLE
Fix AdminLayout imports

### DIFF
--- a/client/src/pages/admin/add-product.tsx
+++ b/client/src/pages/admin/add-product.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "wouter";
-import AdminLayout from "@/components/admin/layout";
+import AdminLayout from "@/components/admin/AdminLayout";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import AdminLayout from "@/components/admin/layout";
+import AdminLayout from "@/components/admin/AdminLayout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { 

--- a/client/src/pages/admin/products.tsx
+++ b/client/src/pages/admin/products.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
-import AdminLayout from "@/components/admin/layout";
+import AdminLayout from "@/components/admin/AdminLayout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { 


### PR DESCRIPTION
## Summary
- use `AdminLayout` from `@/components/admin/AdminLayout`

## Testing
- `npm run check` *(fails: cannot find modules)*