### PR TITLE
Fix shared alias imports

### DIFF
--- a/client/src/components/home/CategoryShowcase.tsx
+++ b/client/src/components/home/CategoryShowcase.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
-import type { Category } from "../../../shared/schema";
+import type { Category } from "@shared/schema";
 
 export default function CategoryShowcase() {
   const { data: categories, isLoading } = useQuery<Category[]>({

--- a/client/src/components/home/FeaturedBlogs.tsx
+++ b/client/src/components/home/FeaturedBlogs.tsx
@@ -3,7 +3,7 @@ import { Link } from "wouter";
 import { formatDistanceToNow } from "date-fns";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import type { BlogPost } from "../../../shared/schema";
+import type { BlogPost } from "@shared/schema";
 
 export default function FeaturedBlogs() {
   const { data: blogPosts, isLoading } = useQuery<BlogPost[]>({

--- a/client/src/components/home/FeaturedProducts.tsx
+++ b/client/src/components/home/FeaturedProducts.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import type { Product } from "../../../shared/schema";
+import type { Product } from "@shared/schema";
 
 export default function FeaturedProducts() {
   const [visibleProducts, setVisibleProducts] = useState(8);

--- a/client/src/components/home/Testimonials.tsx
+++ b/client/src/components/home/Testimonials.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import type { Testimonial } from "../../../shared/schema";
+import type { Testimonial } from "@shared/schema";
 
 export default function Testimonials() {
   const [activeIndex, setActiveIndex] = useState(0);

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from "react";
-import type { User } from "../../shared/schema";
+import type { User } from "@shared/schema";
 
 // Simplified InsertUser type
 interface InsertUser {

--- a/client/src/context/CartContext.tsx
+++ b/client/src/context/CartContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from "react";
 import { v4 as uuidv4 } from "uuid";
-import type { Product } from "../../shared/schema";
+import type { Product } from "@shared/schema";
 
 // Extended CartItem with product details
 export interface CartItemWithProduct {

--- a/client/src/context/SearchContext.tsx
+++ b/client/src/context/SearchContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, ReactNode } from "react";
-import type { Product } from "../../shared/schema";
+import type { Product } from "@shared/schema";
 
 interface SearchContextType {
   searchQuery: string;

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/context/AuthContext";
-import { insertUserSchema } from "../../../shared/schema";
+import { insertUserSchema } from "@shared/schema";
 
 // Login form schema
 const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- use `@shared` alias imports in `client/src`

## Testing
- `npm run check` *(fails: Cannot find module '@/contexts/CartContext', etc.)*