### PR TITLE
Fix build: add missing pkg dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "netlify-plugin-a11y": "^0.0.12",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
+    "pkg": "^4.0.2",
     "postcss-cli": "^11.0.1",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",


### PR DESCRIPTION
## Summary
- add `pkg` to dependencies

## Testing
- `npm run check` *(fails: many TypeScript errors)*