### PR TITLE
Fix bundler settings for ESM

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
 [build.environment]
   NODE_VERSION = "20"
   NPM_FLAGS = "--legacy-peer-deps"
+  CSS_TRANSFORMER_WASM = "false"
 
 [functions]
   directory = "netlify/functions"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --external:esbuild --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,8 @@ export default defineConfig({
     rollupOptions: {
       output: {
         format: "esm"
-      }
+      },
+      external: ["esbuild"]
     }
   },
 });


### PR DESCRIPTION
## Summary
- ensure esbuild remains external when bundling
- disable CSS wasm transformer in Netlify

## Testing
- `npm run build`
