### PR TITLE
Fix clone path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ A professional gardening e-commerce platform offering comprehensive product list
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/yourusername/okkyno.git
-   cd okkyno
+   git clone https://github.com/yourusername/okkyno.com.git
+   cd okkyno.com
    ```
 
 2. Install dependencies:


### PR DESCRIPTION
## Summary
- correct repository path in README clone instructions

## Testing
- `npm run check` *(fails: TS errors)*