### PR TITLE
Fix caching of node modules

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
-  NPM_FLAGS = "--legacy-peer-deps"
+  NPM_FLAGS = "--legacy-peer-deps --prefer-offline --no-audit"
 
 [functions]
   directory = "netlify/functions"
@@ -153,3 +153,9 @@
 
   [plugins.inputs]
     checkPaths = ['/']
+
+[[plugins]]
+  package = "@netlify/plugin-cache"
+
+  [plugins.inputs]
+    paths = ["node_modules"]


### PR DESCRIPTION
## Summary
- adjust npm flags for offline builds
- add cache plugin for node modules

## Testing
- `npm run check` *(fails: product-related type errors)*