### PR TITLE
Fix Netlify plugin-cache version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "ws": "^8.18.0",
         "zod": "^3.23.8",
         "zod-validation-error": "^3.4.0",
-        "@netlify/plugin-cache": "^6.0.0"
+        "@netlify/plugin-cache": "^5.0.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "zod-validation-error": "^3.4.0",
     "serverless-http": "^3.1.0",
     "dayjs": "^1.11.10",
-    "@netlify/plugin-cache": "^6.0.0"
+    "@netlify/plugin-cache": "^5.0.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -104,7 +104,7 @@
     "autoprefixer": "^10.4.21",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
-    "@netlify/plugin-cache": "^6.0.0",
+    "@netlify/plugin-cache": "^5.0.0",
     "netlify-plugin-checklinks": "^4.1.1",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",


### PR DESCRIPTION
## Summary
- update `@netlify/plugin-cache` to a published version in dependencies and devDependencies

## Testing
- `npm run check` *(fails: Property errors in TypeScript)*