### PR TITLE
Fix product generator types

### DIFF
--- a/client/src/lib/product-generator.ts
+++ b/client/src/lib/product-generator.ts
@@ -1,7 +1,7 @@
 import { sampleFeaturedProducts, productImages } from "./data";
 import type { Product } from "@shared/schema";
 
-export interface ExtendedProduct extends Partial<Product> {
+export interface ExtendedProduct extends Product {
   salePrice?: number | null;
   inStock?: boolean;
   isFeatured?: boolean;


### PR DESCRIPTION
## Summary
- ensure `ExtendedProduct` extends `Product`

## Testing
- `npm run check` *(fails: Cannot find modules, type errors)*