### PR TITLE
Fix placeholder SVG paths

### DIFF
--- a/client/src/components/blog/BlogDetail.tsx
+++ b/client/src/components/blog/BlogDetail.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/context/AuthContext';
 import { formatDate, getInitials } from '@/utils/formatters';
 import BlogCard from '@/components/blog/BlogCard';
+import placeholderAvatar from '/placeholder-avatar.svg?url';
 
 interface BlogDetailProps {
   postSlug: string;
@@ -195,7 +196,7 @@ export default function BlogDetail({ postSlug }: BlogDetailProps) {
         {author && (
           <div className="bg-light p-6 rounded-lg flex flex-col md:flex-row items-center mb-12">
             <Avatar className="h-20 w-20 mb-4 md:mb-0 md:mr-6">
-              <AvatarImage src="/placeholder-avatar.svg" alt={author.username} />
+              <AvatarImage src={placeholderAvatar} alt={author.username} />
               <AvatarFallback>{getInitials(author.firstName || author.username)}</AvatarFallback>
             </Avatar>
             <div className="text-center md:text-left">

--- a/client/src/components/cart/CartItem.tsx
+++ b/client/src/components/cart/CartItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'wouter';
 import { Trash2, Minus, Plus } from 'lucide-react';
+import placeholderProduct from '/placeholder-product.svg?url';
 import { Button } from '@/components/ui/button';
 import { CartItem as CartItemType } from '@/context/CartContext';
 import { formatPrice } from '@/utils/formatters';
@@ -66,7 +67,7 @@ export default function CartItem({ item }: CartItemProps) {
       <div className="w-20 h-20 flex-shrink-0 bg-gray-100 rounded overflow-hidden">
         <Link href={`/products/${product.slug}`}>
           <img loading="lazy"
-            src={product.imageUrl || "/placeholder-product.svg"}
+            src={product.imageUrl || placeholderProduct}
             alt={product.name}
             className="w-full h-full object-cover"
           />

--- a/client/src/components/products/ProductCard.tsx
+++ b/client/src/components/products/ProductCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'wouter';
 import { Heart } from 'lucide-react';
+import placeholderProduct from '/placeholder-product.svg?url';
 import { Button } from '@/components/ui/button';
 import { Rating } from '@/components/ui/rating';
 import { useToast } from '@/hooks/use-toast';
@@ -65,7 +66,7 @@ export function ProductCard({ product }: ProductCardProps) {
       <Link href={`/products/${product.slug}`} className="block">
         <div className="relative h-60 overflow-hidden">
           <img loading="lazy"
-            src={product.imageUrl || "/placeholder-product.svg"}
+            src={product.imageUrl || placeholderProduct}
             alt={product.name}
             className="w-full h-full object-cover group-hover:scale-105 transition duration-300"
           />

--- a/client/src/components/products/ProductDetail.tsx
+++ b/client/src/components/products/ProductDetail.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { 
-  Minus, 
-  Plus, 
-  ShoppingCart, 
-  Heart, 
-  Share2, 
-  ArrowLeft, 
+import {
+  Minus,
+  Plus,
+  ShoppingCart,
+  Heart,
+  Share2,
+  ArrowLeft,
   Truck,
   Shield,
   RefreshCw
 } from 'lucide-react';
+import placeholderProduct from '/placeholder-product.svg?url';
 import { Product, Category } from '@shared/schema';
 import { Button } from '@/components/ui/button';
 import { Rating } from '@/components/ui/rating';
@@ -98,7 +99,7 @@ export default function ProductDetail({ productSlug }: ProductDetailProps) {
     
     // If no images, use a placeholder
     if (images.length === 0) {
-      images.push("/placeholder-product.svg");
+      images.push(placeholderProduct);
     }
     
     return images;

--- a/client/src/pages/admin/products.tsx
+++ b/client/src/pages/admin/products.tsx
@@ -14,6 +14,7 @@ import {
   FaChevronLeft,
   FaChevronRight
 } from "react-icons/fa";
+import placeholderProduct from "/placeholder-product.svg?url";
 import { 
   Select, 
   SelectContent, 
@@ -254,7 +255,7 @@ export default function AdminProducts() {
                         <td className="px-4 py-3">
                           <div className="flex items-center">
                               <img
-                                src={product.imageUrl ?? "/placeholder-product.svg"}
+                                src={product.imageUrl ?? placeholderProduct}
                                 alt={product.name}
                               className="w-12 h-12 rounded object-cover mr-3"
                             />

--- a/client/src/pages/product.tsx
+++ b/client/src/pages/product.tsx
@@ -24,6 +24,7 @@ import {
   FaShoppingCart,
   FaRegHeart
 } from "react-icons/fa";
+import placeholderAvatar from "/placeholder-avatar.svg?url";
 
 export default function ProductPage() {
   const [match, params] = useRoute("/product/:slug");
@@ -441,7 +442,7 @@ export default function ProductPage() {
                       <div className="flex justify-between mb-2">
                         <div className="flex items-center">
                           <img loading="lazy"
-                            src="/placeholder-avatar.svg"
+                            src={placeholderAvatar}
                             alt="Reviewer"
                             className="w-10 h-10 rounded-full mr-3"
                           />


### PR DESCRIPTION
## Summary
- import placeholder SVGs with `?url`
- use imported URLs so images load correctly

## Testing
- `npm run check` *(fails: TypeScript errors in admin pages)*